### PR TITLE
Add another storage account to ServiceHub

### DIFF
--- a/overlay.resource.region/source/Parameters/{CLOUDENV}.{DEPLOYENV}.{REGION}.servicehub.sa.Parameters.json
+++ b/overlay.resource.region/source/Parameters/{CLOUDENV}.{DEPLOYENV}.{REGION}.servicehub.sa.Parameters.json
@@ -5,6 +5,9 @@
         "storageaccount_name": {
             "value": "{resource_name_prefix_nodash}shusa{region_short_name}"
         },
+        "storageaccount_name2": {
+            "value": "{resource_name_prefix_nodash}shusa2{region_short_name}"
+        },
         "storage_sku": {
             "value": "{most_reliable_storage_sku}"
         }

--- a/overlay.resource.region/source/Templates/servicehub.sa.Template.json
+++ b/overlay.resource.region/source/Templates/servicehub.sa.Template.json
@@ -25,6 +25,22 @@
                 "allowBlobPublicAccess": false,
                 "allowSharedKeyAccess": false
             }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2019-06-01",
+            "name": "[concat(parameters('storageaccount_name'),'2')]",
+            "location": "[resourceGroup().location]",
+            "kind": "StorageV2",
+            "sku": {
+                "name": "[parameters('storage_sku')]",
+                "tier": "Standard"
+            },
+            "properties": {
+                "accessTier": "Hot",
+                "allowBlobPublicAccess": false,
+                "allowSharedKeyAccess": false
+            }
         }
     ]
 }


### PR DESCRIPTION
Related to #1

Adds a second storage account to the ServiceHub infrastructure and updates parameters to support this addition.

- **Template Update**: Introduces a new storage account resource in `overlay.resource.region/source/Templates/servicehub.sa.Template.json` with the same configuration as the existing one but with a name that appends '2' to the original name parameter. This ensures consistency in storage account properties such as `Standard` SKU, `Hot` access tier, and security settings (public blob access and shared key access disabled).
- **Parameters Update**: Adds a new parameter for the second storage account name in `overlay.resource.region/source/Parameters/{CLOUDENV}.{DEPLOYENV}.{REGION}.servicehub.sa.Parameters.json`, ensuring it follows the naming convention `{resource_name_prefix_nodash}shusa2{region_short_name}` and uses the same SKU as the existing storage account.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/toma3233/ev2/issues/1?shareId=2e1a3942-3169-41ec-a817-03d61370a1e3).